### PR TITLE
fixed rel path issue with private file LevelSequenceEditorToolkit.h

### DIFF
--- a/Source/ThreepeatAnimTools/Public/ThreepeatAnimToolsBPLibrary.h
+++ b/Source/ThreepeatAnimTools/Public/ThreepeatAnimToolsBPLibrary.h
@@ -5,11 +5,10 @@
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "LevelSequence.h"
-//#include "LevelSequenceEditorToolkit.h"
+#include "LevelSequenceEditorToolkit.h"
 //#include "ISequencer.h"
 #include "UObject/ObjectMacros.h"
 #include "MovieSceneBindingProxy.h"
-#include "../../../../../../../Engines/UE_5.4/Engine/Plugins/MovieScene/LevelSequenceEditor/Source/LevelSequenceEditor/Private/LevelSequenceEditorToolkit.h"
 
 #include "ThreepeatAnimToolsBPLibrary.generated.h"
 

--- a/Source/ThreepeatAnimTools/ThreepeatAnimTools.Build.cs
+++ b/Source/ThreepeatAnimTools/ThreepeatAnimTools.Build.cs
@@ -1,6 +1,7 @@
 // Some copyright should be here...
 
 using UnrealBuildTool;
+using System.IO;
 
 public class ThreepeatAnimTools : ModuleRules
 {
@@ -17,7 +18,7 @@ public class ThreepeatAnimTools : ModuleRules
 		
 		PrivateIncludePaths.AddRange(
 			new string[] {
-				// ... add other private include paths required here ...
+				Path.Combine(GetModuleDirectory("LevelSequenceEditor"), "Private")
 			}
 			);
 			


### PR DESCRIPTION
This fixes the issue if the engine does not reside specifically in the relative path and engine 
 version.